### PR TITLE
Switch to web-feature-explorer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ from the Web Features project.
 This is inspired by the official
 [`baseline-status` component](https://github.com/web-platform-dx/baseline-status)
 from Google and the Web Platform DX community group.
-It currently uses their `https://api.webstatus.dev/v1/features/` API.
+It uses the API provided by the
+[Web platform features explorer](https://web-platform-dx.github.io/web-features-explorer/).
 
 ## Features
 


### PR DESCRIPTION
## Description
Switches from the web.dev API to the raw data available from the Explorer. This is the data from the web-features package, augmented with data from https://github.com/web-platform-dx/web-features-mappings. This PR doesn't take advantage of any of the augmented data, but it includes things like MDN links, WPT tests, standards positions, etc.


The web.dev API did some data transformation for the status, adding `limited` and changing `low` to `newly` and `high` to `widely`. I decided that the data should match the web-features terminology, and the displayed text should be transformed.

## Related Issue(s)
#6 
