### PR TITLE
Bump version 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 Breaking changes will be allowed in minor versions
 until we achieve a stable v1.0 release
 
+## v0.1.2 - 2026-01-12
+
+- Fix: Use the API from
+  [Web platform features explorer](https://web-platform-dx.github.io/web-features-explorer/)
+- Docs: Add note about webC Javascript bundling
+
 ## v0.1.1 - 2025-10-17
 
 - Label and clarify the narrow-to-wide support progress bar

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Make sure you include the `<script>` in your project
 
 Or use the built-in
 [WebC](https://www.11ty.dev/docs/languages/webc/) component
-with [Eleventy](https://www.11ty.dev/docs/),
-by adding `"npm:@oddbird/browser-support/*.webc"`
+with [Eleventy](https://www.11ty.dev/docs/).
+First add `"npm:@oddbird/browser-support/*.webc"`
 to the Eleventy WebC Plugin `components` registry:
 
 ```js
@@ -93,6 +93,13 @@ module.exports = function (eleventyConfig) {
     ],
   });
 }
+```
+
+Then make sure to include WebC bundled JS
+somewhere in your layout:
+
+```html
+<script webc:keep @raw="getBundle('js')" type="module"></script>
 ```
 
 ### Slots

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oddbird/browser-support",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A web component for showing browser-support data from the Web Features project",
   "main": "browser-support.js",
   "scripts": {


### PR DESCRIPTION
![](https://picsum.photos/600/400?release)


## Description
Uncomment if you want to provide a custom description.

- Update docs for using webC (closes #3)
- Release API update (closes #6)
- Bump version to 0.1.2